### PR TITLE
Fix file type detection in sendFile helper

### DIFF
--- a/lib/simple.js
+++ b/lib/simple.js
@@ -131,30 +131,31 @@ export function makeWASocket(connectionOptions, options = {}) {
 					isStream = true
 				}
 
-				const streamWithType = await fileTypeStream(data) ||
-					{ ...data, mime: 'application/octet-stream', ext: '.bin' }
+                                const streamWithType = await fileTypeStream(data)
+                                const fileType = streamWithType?.fileType || { mime: 'application/octet-stream', ext: 'bin' }
+                                const stream = streamWithType?.stream || data
 
-				if (data && saveToFile && !filename) {
-					filename = path.join(__dirname, `../tmp/${Date.now()}.${streamWithType.fileType.ext}`)
-					await Helper.saveStreamToFile(data, filename)
-				}
+                                if (data && saveToFile && !filename) {
+                                        filename = path.join(__dirname, `../tmp/${Date.now()}.${fileType.ext}`)
+                                        await Helper.saveStreamToFile(stream, filename)
+                                }
 
-				return {
-					res,
-					filename,
-					...streamWithType.fileType,
-					data: streamWithType,
-					async toBuffer() {
-						const buffers = []
-						for await (const chunk of streamWithType) buffers.push(chunk)
-						return Buffer.concat(buffers)
-					},
-					async clear() {
-						// if (res) /** @type {Response} */ (res).body
-						streamWithType.destroy()
-						if (filename) await fs.promises.unlink(filename)
-					}
-				}
+                                return {
+                                        res,
+                                        filename,
+                                        ...fileType,
+                                        data: stream,
+                                        async toBuffer() {
+                                                const buffers = []
+                                                for await (const chunk of stream) buffers.push(chunk)
+                                                return Buffer.concat(buffers)
+                                        },
+                                        async clear() {
+                                                // if (res) /** @type {Response} */ (res).body
+                                                stream.destroy()
+                                                if (filename) await fs.promises.unlink(filename)
+                                        }
+                                }
 			},
 			enumerable: true,
 			writable: true,
@@ -207,8 +208,8 @@ export function makeWASocket(connectionOptions, options = {}) {
 					convert
 				const opt = {}
 
-				if (quoted) opt.quoted = quoted
-				if (!file.ext === '.bin') options.asDocument = true
+                                if (quoted) opt.quoted = quoted
+                                if (!file.ext || file.ext === 'bin') options.asDocument = true
 
 				if (/webp/.test(file.mime) || (/image/.test(file.mime) && options.asSticker)) mtype = 'sticker'
 				else if (/image/.test(file.mime) || (/webp/.test(file.mime) && options.asImage)) mtype = 'image'


### PR DESCRIPTION
## Summary
- handle missing file type data in `getFile`
- treat unknown extension files as documents in `sendFile`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958b1aee908327a87bf08d1601c43d